### PR TITLE
Set BUILD_TIME and BUILD_VERSION in projenv scope to avoid full rebuild

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ build_flags =
     -D DEFAULT_UART_BAUDRATE=9600
     -D USE_FULL_ERROR_LIST
 extra_scripts = 
-	pre:scripts/get_version.py
+	post:scripts/get_version.py
 
 [env:esp12e]
 board = esp12e
@@ -29,7 +29,7 @@ build_flags =
     -D LED_BUILTIN=2
 extra_scripts =
     ${env.extra_scripts}
-	pre:scripts/get_build_time.py
+	post:scripts/get_build_time.py
     scripts/make_gz.py
 upload_port = 
 upload_resetmethod = nodemcu

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,8 @@ build_flags =
     -D DEFAULT_UART_BAUDRATE=9600
     -D USE_FULL_ERROR_LIST
 extra_scripts = 
-	post:scripts/get_version.py
+    pre:scripts/get_version_pre.py
+    post:scripts/get_version_post.py
 
 [env:esp12e]
 board = esp12e

--- a/scripts/get_build_time.py
+++ b/scripts/get_build_time.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-Import("env")
+Import("env", "projenv")
 from datetime import datetime, timezone
 
 # get current datetime
@@ -10,6 +10,6 @@ now = datetime.now(timezone.utc)
 build_time = now.astimezone().isoformat(timespec='seconds')
 
 # Append the timestamp to the build defines so it gets baked into the firmware
-env.Append(CPPDEFINES=[
+projenv.Append(CPPDEFINES=[
     f'BUILD_TIME={build_time}',
 ])

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-Import("env")
+Import("env", "projenv")
 import os
 
 # Get the version number from the build environment.
@@ -16,7 +16,7 @@ if firmware_version == "":
 print(f'Using version {firmware_version} for the build')
 
 # Append the version to the build defines so it gets baked into the firmware
-env.Append(CPPDEFINES=[
+projenv.Append(CPPDEFINES=[
     f'BUILD_VERSION={firmware_version}',
 ])
 

--- a/scripts/get_version_post.py
+++ b/scripts/get_version_post.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 Peder Toftegaard Olsen
+#
+# SPDX-License-Identifier: MIT
+
+Import("env", "projenv")
+
+# Get the version number from the build environment.
+firmware_version = env.get('FIRMWARE_VERSION', "")
+
+# Append the version to the build defines so it gets baked into the firmware
+projenv.Append(CPPDEFINES=[
+    f'BUILD_VERSION={firmware_version}',
+])
+

--- a/scripts/get_version_pre.py
+++ b/scripts/get_version_pre.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024 Peder Toftegaard Olsen
+#
+# SPDX-License-Identifier: MIT
+
+Import("env")
+import os
+
+# Get the version number from the build environment.
+firmware_version = os.environ.get('VERSION', "")
+
+# Clean up the version number
+if firmware_version == "":
+    # When no version is specified default to "DEVELOPMENT"
+    firmware_version = "DEVELOPMENT"
+
+print(f'Using version {firmware_version} for the build')
+
+env.Append(FIRMWARE_VERSION=f'{firmware_version}')
+
+if firmware_version != "DEVELOPMENT":
+    # Set the output filename to the name of the board and the version
+    env.Replace(PROGNAME=f'firmware_{env["PIOENV"]}_{firmware_version.replace(".", "_")}')


### PR DESCRIPTION
Defining different BUILD_TIME for whole env causes every file (including framework and libs) to be recompilled on every build.
Changing to projenv will set those defines only for actual project files reducing build time considerably.
However projenv is only available in POST scripts, so I had to split get_version into two parts.