### PR TITLE
vxi server more robust against connection drops

### DIFF
--- a/src/vxi11_server/vxi_server.cpp
+++ b/src/vxi11_server/vxi_server.cpp
@@ -77,10 +77,15 @@ void VXI_Server::loop()
     if (client) // if a connection has been established on port
     {
         bool bClose = false;
-        int len = get_vxi_packet(client);
 
-        if (len > 0) {
-            bClose = handle_packet();
+        if (!client.connected()) {
+            bClose = true;
+        } else {
+            int len = get_vxi_packet(client);
+
+            if (len > 0) {
+                bClose = handle_packet();
+            }
         }
 
         if (bClose) {


### PR DESCRIPTION
The server was missing a disconnect check, making it hang if the connected client killed without the server participating in the kill.